### PR TITLE
Background colour defaults to border colour with more transparency wh…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "chartjs-plugin-datasource-prometheus",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "chartjs-plugin-datasource-prometheus",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "prometheus-query": "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "Samuel Berthe",
     "Frantisek Svoboda"
   ],
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "main": "dist/chartjs-plugin-datasource-prometheus.cjs.js",
   "module": "dist/chartjs-plugin-datasource-prometheus.esm.js",

--- a/src/options.ts
+++ b/src/options.ts
@@ -81,30 +81,15 @@ export class ChartDatasourcePrometheusPluginOptions {
         'rgba(255, 159, 64, 1)'
     ];
     backgroundColor?: string[] = [
-        'transparent',
-        'transparent',
-        'transparent',
-        'transparent',
-        'transparent',
-        'transparent',
-        'transparent',
-        'transparent',
 
-        // 'rgba(0, 63, 92, 0.2)',
-        // 'rgba(47, 75, 124, 0.2)',
-        // 'rgba(102, 81, 145, 0.2)',
-        // 'rgba(160, 81, 149, 0.2)',
-        // 'rgba(212, 80, 135, 0.2)',
-        // 'rgba(249, 93, 106, 0.2)',
-        // 'rgba(255, 124, 67, 0.2)',
-        // 'rgba(255, 166, 0, 0.2)',
+        // 'transparent'
 
-        // 'rgba(255, 99, 132, 0.2)',
-        // 'rgba(54, 162, 235, 0.2)',
-        // 'rgba(255, 206, 86, 0.2)',
-        // 'rgba(75, 192, 192, 0.2)',
-        // 'rgba(153, 102, 255, 0.2)',
-        // 'rgba(255, 159, 64, 0.2)'
+        'rgba(255, 99, 132, 0.2)',
+        'rgba(54, 162, 235, 0.2)',
+        'rgba(255, 206, 86, 0.2)',
+        'rgba(75, 192, 192, 0.2)',
+        'rgba(153, 102, 255, 0.2)',
+        'rgba(255, 159, 64, 0.2)'
     ];
     noDataMsg?: ChartDatasourcePrometheusPluginNoDataMsg = new ChartDatasourcePrometheusPluginNoDataMsg();
     errorMsg?: ChartDatasourcePrometheusPluginErrorMsg = new ChartDatasourcePrometheusPluginErrorMsg();

--- a/src/serie.ts
+++ b/src/serie.ts
@@ -10,7 +10,7 @@ export function selectLabel(options: ChartDatasourcePrometheusPluginOptions, ser
 }
 
 export function selectBackGroundColor(options: ChartDatasourcePrometheusPluginOptions, serie, i) {
-    const defaultValue = options.backgroundColor[i % options.backgroundColor.length];
+    const defaultValue = !options.fill ? 'transparent' : options.backgroundColor[i % options.backgroundColor.length];
     if (options.findInBackgroundColorMap) {
         return options.findInBackgroundColorMap(serie.metric) || defaultValue;
     }


### PR DESCRIPTION
I started using this package, but it looks like `options.fill` doesn't behave as expected (at least according to my interpretation, which could be wrong).

**Current functionality:** When `options.fill` is set to something, the graphs do not render with a fill colour unless the user also specifically defines an array of colours for the `backgroundColor` property. This is contrary to the behaviour of the `borderColor` property which conveniently defaults to a 'random' colour for the user.

**Proposed Functionality:** When a user sets a value for options.fill, the `backgroundColor` property should default to a more transparent version of the border colour chosen for that data set. This is consistent with normal Graphana behaviour.

I have made a modification to the code that does this after setting `options.fill` to any Javascript 'truthy' value. It uses the existing commented out fill colours that are, in my eyes, were a good amount of 'more transparent'