### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ chartjs-plugin-datasource-prometheus can be used with ES6 modules, plain JavaScr
 Then, you need to register the plugin to enable it for all charts in the page.
 
 ```js
-Chart.plugins.register(ChartDatasourcePrometheusPlugin);
+Chart.registry.plugins.register(ChartDatasourcePrometheusPlugin);
 ```
 
 Or, you can enable the plugin only for specific charts.

--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ npm install chartjs-plugin-datasource-prometheus --save
 
 Via CDN:
 
+Add inside of `<head>` the following:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.2.1/dist/Chart.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.2.1/dist/Chart.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js" crossorigin="anonymous"></script>
 
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus/dist/chartjs-plugin-datasource-prometheus.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus/dist/chartjs-plugin-datasource-prometheus.umd.min.js" crossorigin="anonymous"></script>
 ```
 
 💡 Note that chartjs-plugin-datasource-prometheus must be loaded after Chart.js and the date-fns adapter

--- a/README.md
+++ b/README.md
@@ -57,13 +57,16 @@ Via CDN:
 
 Add inside of `<head>` the following:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.2.1/dist/Chart.min.js" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js" crossorigin="anonymous"></script>
-
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus/dist/chartjs-plugin-datasource-prometheus.umd.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3/dist/chartjs-adapter-date-fns.bundle.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus@2.0/dist/chartjs-plugin-datasource-prometheus.umd.min.js" crossorigin="anonymous"></script>
 ```
 
-💡 Note that chartjs-plugin-datasource-prometheus must be loaded after Chart.js and the date-fns adapter
+💡 Note that chartjs-plugin-datasource-prometheus must be loaded after Chart.js and the date-fns adapter.
+
+Here is used the jsDelivr CDN with specifying only a major version so any minor and patch updates will be applied automatically.
+If you need to use a specific version or ESM the copy link from https://www.jsdelivr.com/package/npm/chartjs-plugin-datasource-prometheus
+
 
 ## 💡 Quick start
 

--- a/example/index.html
+++ b/example/index.html
@@ -23,11 +23,11 @@
     </div>
   </div>
 
-  <script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
-  <script type="application/javascript" src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.js"></script>
-  <script type="application/javascript" src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@1.0.0"></script>
-  <script type="application/javascript" src="../dist/chartjs-plugin-datasource-prometheus.umd.js"></script>
-  <script type="application/javascript" src="main.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.js " crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@1.0.0" crossorigin="anonymous"></script>
+  <script src="../dist/chartjs-plugin-datasource-prometheus.umd.js" crossorigin="anonymous"></script>
+  <script src="main.js"></script>
 </body>
 
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -23,9 +23,8 @@
     </div>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.js " crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@1.0.0" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3/dist/chartjs-adapter-date-fns.bundle.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus@2.0/dist/chartjs-plugin-datasource-prometheus.umd.min.js" crossorigin="anonymous"></script>
   <script src="main.js"></script>
 </body>

--- a/example/index.html
+++ b/example/index.html
@@ -26,7 +26,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.js " crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@1.0.0" crossorigin="anonymous"></script>
-  <script src="../dist/chartjs-plugin-datasource-prometheus.umd.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus@2.0/dist/chartjs-plugin-datasource-prometheus.umd.min.js" crossorigin="anonymous"></script>
   <script src="main.js"></script>
 </body>
 


### PR DESCRIPTION
The CDN urls are old or broken.
Also for me it's unclear the new chartjs-adapter-date-fns: as far I understood it contains the date-fns library included. Because I didn't added it but everything looks working