### PR TITLE
CDN urls: use major 2 without minor 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Add inside of `<head>` the following:
 ```html
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3/dist/chartjs-adapter-date-fns.bundle.min.js" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus@2.0/dist/chartjs-plugin-datasource-prometheus.umd.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus@2/dist/chartjs-plugin-datasource-prometheus.umd.min.js" crossorigin="anonymous"></script>
 ```
 
 💡 Note that chartjs-plugin-datasource-prometheus must be loaded after Chart.js and the date-fns adapter.

--- a/example/index.html
+++ b/example/index.html
@@ -25,7 +25,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3/dist/chartjs-adapter-date-fns.bundle.min.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus@2.0/dist/chartjs-plugin-datasource-prometheus.umd.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datasource-prometheus@2/dist/chartjs-plugin-datasource-prometheus.umd.min.js" crossorigin="anonymous"></script>
   <script src="main.js"></script>
 </body>
 


### PR DESCRIPTION
Sorry, I made the mistake and now the update is not grabbed. 