### PR TITLE
Replace deprecated `destroy` hook with `afterDestroy`.

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -191,7 +191,7 @@ export class ChartDatasourcePrometheusPlugin {
         ctx.restore();
     }
 
-    public destroy(chart: Chart, args: any, _options: any) {
+    public afterDestroy(chart: Chart, args: any, _options: any) {
         // auto update
         if (!!chart['datasource-prometheus'].updateInterval)
             clearInterval(chart['datasource-prometheus'].updateInterval);


### PR DESCRIPTION
As per ChartJS 3.7.0, `destroy` is deprecated in favour of `afterDestroy`: https://www.chartjs.org/docs/latest/developers/plugins.html#chart-destroy

As `destroy` no longer gets called, the update interval never gets unset, and charts continue to try and update themselves after being destroyed (leading to errors in the JS console, and presumably an associated memory leak).

Resolves #46.